### PR TITLE
Switch to 2.3.0-SNAPSHOT in the RM adaptor

### DIFF
--- a/adaptor-rm-webapp/.gitignore
+++ b/adaptor-rm-webapp/.gitignore
@@ -1,3 +1,3 @@
 /target/
-
+/overlays/
 /.settings/

--- a/adaptor-rm-webapp/pom.xml
+++ b/adaptor-rm-webapp/pom.xml
@@ -12,8 +12,8 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<version.lyo.core>2.2.0</version.lyo.core>
-		<version.lyo.server>2.2.0</version.lyo.server>
+		<version.lyo.core>2.3.0-SNAPSHOT</version.lyo.core>
+		<version.lyo.server>2.3.0-SNAPSHOT</version.lyo.server>
 	</properties>
 	<repositories>
 		<repository>

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/servlet/Application.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/servlet/Application.java
@@ -27,7 +27,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-
+import org.apache.jena.JenaRuntime;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.impl.RDFWriterFImpl;
 import org.eclipse.lyo.oslc4j.application.OslcWinkApplication;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
 import org.eclipse.lyo.oslc4j.core.model.AllowedValues;
@@ -88,7 +90,18 @@ public class Application extends OslcWinkApplication {
         RESOURCE_CLASSES.add(ResourceShapeService.class);
 
         // Start of user code Custom Resource Classes
-            // End of user code
+
+        // trigger Jena init
+        ModelFactory.createDefaultModel();
+        // force plain XML writer
+        RDFWriterFImpl.alternative(null);
+
+        //other things that didn't help
+        JenaRuntime.isRDF11 = false;
+//        final String abbrevProp = System.getProperty(
+//                "org.eclipse.lyo.oslc4j.alwaysXMLAbbrevOnlyProviders");
+
+        // End of user code
 
         RESOURCE_SHAPE_PATH_TO_RESOURCE_CLASS_MAP.put(OslcConstants.PATH_ALLOWED_VALUES,           AllowedValues.class);
         RESOURCE_SHAPE_PATH_TO_RESOURCE_CLASS_MAP.put(OslcConstants.PATH_COMPACT,                  Compact.class);

--- a/adaptor-testing-webapp/.gitignore
+++ b/adaptor-testing-webapp/.gitignore
@@ -1,3 +1,3 @@
 /target/
-
+/overlays/
 /.settings/


### PR DESCRIPTION
This is the code needed to maintain the non-abbrev output, see more details in https://issues.apache.org/jira/browse/JENA-1477

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oslc/lyo-adaptor-sample-modelling/12)
<!-- Reviewable:end -->
