### PR TITLE
Showcase how HTML code can be moved out of resources

### DIFF
--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Helper.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Helper.java
@@ -1,0 +1,18 @@
+package com.sample.rm.resources;
+
+/**
+ * TBD
+ *
+ * @version $version-stub$
+ * @since FIXME
+ */
+public interface Helper<T> {
+    String resourceToString(boolean asLocalResource);
+    String resourceToString();
+
+    String resourceToHtml(boolean asLocalResource);
+    String resourceToHtml();
+
+    String resourcePropertyToHtml(String propertyName);
+    String resourcePropertyToHtmlCreation(String propertyName);
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/HelperFactory.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/HelperFactory.java
@@ -1,0 +1,11 @@
+package com.sample.rm.resources;
+
+/**
+ * TBD
+ *
+ * @version $version-stub$
+ * @since FIXME
+ */
+public interface HelperFactory {
+    <T> Helper<T> getHelperFor(T resource);
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Oslc_rmHelperFactory.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Oslc_rmHelperFactory.java
@@ -1,0 +1,22 @@
+package com.sample.rm.resources;
+
+/**
+ * TBD
+ *
+ * @version $version-stub$
+ * @since FIXME
+ */
+public class Oslc_rmHelperFactory implements HelperFactory {
+
+    public static Oslc_rmHelperFactory INSTANCE = new Oslc_rmHelperFactory();
+
+    private Oslc_rmHelperFactory() {}
+
+    @SuppressWarnings("unchecked")
+    public <R> Helper<R> getHelperFor(R resource) {
+        if(resource instanceof Requirement) {
+            return (Helper<R>) new RequirementHelperImpl((Requirement) resource);
+        }
+        throw new IllegalArgumentException("Unknown resource type");
+    }
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Oslc_rmHtmlHelper.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Oslc_rmHtmlHelper.java
@@ -1,0 +1,154 @@
+package com.sample.rm.resources;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * TBD
+ *
+ * @version $version-stub$
+ * @since FIXME
+ */
+public class Oslc_rmHtmlHelper {
+
+    public static String requirementToString(final Requirement resource, boolean asLocalResource)
+    {
+        String result = "";
+        // Start of user code requirementToString_init
+        // End of user code
+
+        if (asLocalResource) {
+            result = result + "{a Local Requirement Resource} - update Requirement.toString() to present resource as desired.";
+            // Start of user code requirementToString_body
+            // End of user code
+        }
+        else {
+            result = resource.getAbout().toString();
+        }
+
+        // Start of user code requirementToString_finalise
+        // End of user code
+
+        return result;
+    }
+
+    public static String requirementToHtml(final Requirement resource)
+    {
+        return requirementToHtml(resource, false);
+    }
+
+    public static String requirementToHtml(Requirement resource, boolean asLocalResource)
+    {
+        String result = "";
+        // Start of user code requirementToHtml_init
+        // End of user code
+
+        if (asLocalResource) {
+            result = requirementToString(resource, true);
+            // Start of user code requirementToHtml_body
+            // End of user code
+        }
+        else {
+            result = "<a href=\"" + resource.getAbout() + "\" class=\"oslc-resource-link\">" + resource.toString() + "</a>";
+        }
+
+        // Start of user code requirementToHtml_init_finalize
+        // End of user code
+
+        return result;
+    }
+
+    public static String titleToHtmlForCreation (final Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code "Init:titleToHtmlForCreation(...)"
+        // End of user code
+
+        s = s + "<label for=\"title\">title: </LABEL>";
+
+        // Start of user code "Mid:titleToHtmlForCreation(...)"
+        // End of user code
+
+        s= s + "<input name=\"title\" type=\"text\" style=\"width: 400px\" id=\"title\" >";
+        // Start of user code "Finalize:titleToHtmlForCreation(...)"
+        // End of user code
+
+        return s;
+    }
+
+    public static String requirementDescriptionToHtmlForCreation (final Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code "Init:descriptionToHtmlForCreation(...)"
+        // End of user code
+
+        s = s + "<label for=\"description\">description: </LABEL>";
+
+        // Start of user code "Mid:descriptionToHtmlForCreation(...)"
+        // End of user code
+
+        // FIXME Andrew@2018-11-12: what about pre-filling for edit?
+        s= s + "<input name=\"description\" type=\"text\" style=\"width: 400px\" id=\"description\" >";
+        // Start of user code "Finalize:descriptionToHtmlForCreation(...)"
+        // End of user code
+
+        return s;
+    }
+
+    public static String requirementTitleToHtml(final Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code titletoHtml_mid
+        // End of user code
+
+        try {
+            // TODO Andrew@2018-11-12: note the switch to use getters
+            if (resource.getTitle() == null) {
+                s = s + "<em>null</em>";
+            }
+            else {
+                s = s + resource.getTitle().toString();
+            }
+        } catch (Exception e) {
+            // FIXME Andrew@2018-11-12: I think this needs to change
+            // option 1: slf4j log
+            // option 2: new IllegalStateException() (can be both)
+            e.printStackTrace();
+        }
+
+        // Start of user code titletoHtml_finalize
+        // End of user code
+
+        return s;
+    }
+
+    public static String requirementDescriptionToHtml(final Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code descriptiontoHtml_mid
+        // End of user code
+
+        try {
+            // TODO Andrew@2018-11-12: consider using Java 8 Optional class for zero-or-one card.
+            if (resource.getDescription() == null) {
+                s = s + "<em>null</em>";
+            }
+            else {
+                s = s + resource.getDescription().toString();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // Start of user code descriptiontoHtml_finalize
+        // End of user code
+
+        return s;
+    }
+
+
+
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Oslc_rmHtmlHelperOverload.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Oslc_rmHtmlHelperOverload.java
@@ -1,0 +1,155 @@
+package com.sample.rm.resources;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * TBD
+ *
+ * @version $version-stub$
+ * @since FIXME
+ */
+public class Oslc_rmHtmlHelperOverload {
+
+    public static String resourceToString(Requirement resource, boolean asLocalResource)
+    {
+        String result = "";
+        // Start of user code requirementToString_init
+        // End of user code
+
+        if (asLocalResource) {
+            result = result + "{a Local Requirement Resource} - update Requirement.toString() to present resource as desired.";
+            // Start of user code requirementToString_body
+            // End of user code
+        }
+        else {
+            result = resource.getAbout().toString();
+        }
+
+        // Start of user code requirementToString_finalise
+        // End of user code
+
+        return result;
+    }
+
+    public static String resourceToHtml(Requirement resource)
+    {
+        return resourceToHtml(resource, false);
+    }
+
+    public static String resourceToHtml(Requirement resource, boolean asLocalResource)
+    {
+        String result = "";
+        // Start of user code requirementToHtml_init
+        // End of user code
+
+        if (asLocalResource) {
+            result = resourceToString(resource, true);
+            // Start of user code requirementToHtml_body
+            // End of user code
+        }
+        else {
+            result = "<a href=\"" + resource.getAbout() + "\" class=\"oslc-resource-link\">" + resource.toString() + "</a>";
+        }
+
+        // Start of user code requirementToHtml_init_finalize
+        // End of user code
+
+        return result;
+    }
+
+    // NB! nothing we can do here as the properties are bound to invidual shapes in this ctx
+    static public String titleToHtmlForCreation(Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code "Init:titleToHtmlForCreation(...)"
+        // End of user code
+
+        s = s + "<label for=\"title\">title: </LABEL>";
+
+        // Start of user code "Mid:titleToHtmlForCreation(...)"
+        // End of user code
+
+        s= s + "<input name=\"title\" type=\"text\" style=\"width: 400px\" id=\"title\" >";
+        // Start of user code "Finalize:titleToHtmlForCreation(...)"
+        // End of user code
+
+        return s;
+    }
+
+    public static String requirementDescriptionToHtmlForCreation (Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code "Init:descriptionToHtmlForCreation(...)"
+        // End of user code
+
+        s = s + "<label for=\"description\">description: </LABEL>";
+
+        // Start of user code "Mid:descriptionToHtmlForCreation(...)"
+        // End of user code
+
+        // FIXME Andrew@2018-11-12: what about pre-filling for edit?
+        s= s + "<input name=\"description\" type=\"text\" style=\"width: 400px\" id=\"description\" >";
+        // Start of user code "Finalize:descriptionToHtmlForCreation(...)"
+        // End of user code
+
+        return s;
+    }
+
+    public static String requirementTitleToHtml(Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code titletoHtml_mid
+        // End of user code
+
+        try {
+            // TODO Andrew@2018-11-12: note the switch to use getters
+            if (resource.getTitle() == null) {
+                s = s + "<em>null</em>";
+            }
+            else {
+                s = s + resource.getTitle().toString();
+            }
+        } catch (Exception e) {
+            // FIXME Andrew@2018-11-12: I think this needs to change
+            // option 1: slf4j log
+            // option 2: new IllegalStateException() (can be both)
+            e.printStackTrace();
+        }
+
+        // Start of user code titletoHtml_finalize
+        // End of user code
+
+        return s;
+    }
+
+    public static String requirementDescriptionToHtml(Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code descriptiontoHtml_mid
+        // End of user code
+
+        try {
+            // TODO Andrew@2018-11-12: consider using Java 8 Optional class for zero-or-one card.
+            if (resource.getDescription() == null) {
+                s = s + "<em>null</em>";
+            }
+            else {
+                s = s + resource.getDescription().toString();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // Start of user code descriptiontoHtml_finalize
+        // End of user code
+
+        return s;
+    }
+
+
+
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Requirement.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Requirement.java
@@ -168,19 +168,24 @@ public class Requirement
         Oslc_rmDomainConstants.REQUIREMENT_PATH,
         Requirement.class);
     }
-    
-    
-    public String toString()
-    {
-        return toString(false);
+
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("Requirement{");
+        sb.append("title='").append(title).append('\'');
+        sb.append(", description='").append(description).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
-    
+
+    @Deprecated
     public String toString(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toString_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = result + "{a Local Requirement Resource} - update Requirement.toString() to present resource as desired.";
             // Start of user code toString_bodyForLocalResource
@@ -189,24 +194,26 @@ public class Requirement
         else {
             result = getAbout().toString();
         }
-    
+
         // Start of user code toString_finalize
         // End of user code
-    
+
         return result;
     }
-    
+
+    @Deprecated
     public String toHtml()
     {
         return toHtml(false);
     }
-    
+
+    @Deprecated
     public String toHtml(boolean asLocalResource)
     {
         String result = "";
         // Start of user code toHtml_init
         // End of user code
-    
+
         if (asLocalResource) {
             result = toString(true);
             // Start of user code toHtml_bodyForLocalResource
@@ -215,14 +222,14 @@ public class Requirement
         else {
             result = "<a href=\"" + getAbout() + "\" class=\"oslc-resource-link\">" + toString() + "</a>";
         }
-    
+
         // Start of user code toHtml_finalize
         // End of user code
-    
+
         return result;
     }
-    
-    
+
+
     // Start of user code getterAnnotation:title
     // End of user code
     @OslcName("title")
@@ -276,7 +283,7 @@ public class Requirement
         // End of user code
     }
     
-    
+    @Deprecated
     static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -295,7 +302,8 @@ public class Requirement
     
         return s;
     }
-    
+
+    @Deprecated
     static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
     {
         String s = "";
@@ -315,7 +323,7 @@ public class Requirement
         return s;
     }
     
-    
+    @Deprecated
     public String titleToHtml()
     {
         String s = "";
@@ -339,7 +347,8 @@ public class Requirement
     
         return s;
     }
-    
+
+    @Deprecated
     public String descriptionToHtml()
     {
         String s = "";

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/RequirementHelperImpl.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/RequirementHelperImpl.java
@@ -1,0 +1,139 @@
+package com.sample.rm.resources;
+
+import javax.xml.namespace.QName;
+
+/**
+ * TBD
+ *
+ * @version $version-stub$
+ * @since FIXME
+ */
+public class RequirementHelperImpl implements Helper<Requirement> {
+    private final Requirement resource;
+
+    public RequirementHelperImpl(final Requirement resource) {
+        this.resource = resource;
+    }
+
+    public String resourceToString(final boolean asLocalResource) {
+        String result = "";
+        // Start of user code requirementToString_init
+        // End of user code
+
+        if (asLocalResource) {
+            result = result + "{a Local Requirement Resource} - update Requirement.toString() to present resource as desired.";
+            // Start of user code requirementToString_body
+            // End of user code
+        }
+        else {
+            result = resource.getAbout().toString();
+        }
+
+        // Start of user code requirementToString_finalise
+        // End of user code
+
+        return result;
+    }
+
+    public String resourceToString() {
+        return resourceToString(false);
+    }
+
+    public String resourceToHtml(final boolean asLocalResource) {
+        String result = "";
+        // Start of user code requirementToHtml_init
+        // End of user code
+
+        if (asLocalResource) {
+            result = resourceToString(true);
+            // Start of user code requirementToHtml_body
+            // End of user code
+        }
+        else {
+            result = "<a href=\"" + resource.getAbout() + "\" class=\"oslc-resource-link\">" + resource.toString() + "</a>";
+        }
+
+        // Start of user code requirementToHtml_init_finalize
+        // End of user code
+
+        return result;
+    }
+
+    public String resourceToHtml() {
+        return resourceToHtml(false);
+    }
+
+    public String resourcePropertyToHtml(final String propertyName) {
+        if("title".equals(propertyName)) {
+            return requirementTitleToHtml(resource);
+        } else if("description".equals(propertyName)) {
+            return requirementDescriptionToHtml(resource);
+        } else {
+            // or something more creative
+            final QName key = QName.valueOf(propertyName);
+            if(resource.getExtendedProperties().containsKey(key)) {
+                return resource.getExtendedProperties().get(key).toString();
+            }
+        }
+
+        throw new IllegalArgumentException("Unknown property");
+    }
+
+    private String requirementTitleToHtml(Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code titletoHtml_mid
+        // End of user code
+
+        try {
+            // TODO Andrew@2018-11-12: note the switch to use getters
+            if (resource.getTitle() == null) {
+                s = s + "<em>null</em>";
+            }
+            else {
+                s = s + resource.getTitle().toString();
+            }
+        } catch (Exception e) {
+            // FIXME Andrew@2018-11-12: I think this needs to change
+            // option 1: slf4j log
+            // option 2: new IllegalStateException() (can be both)
+            e.printStackTrace();
+        }
+
+        // Start of user code titletoHtml_finalize
+        // End of user code
+
+        return s;
+    }
+
+    private String requirementDescriptionToHtml(Requirement resource)
+    {
+        String s = "";
+
+        // Start of user code descriptiontoHtml_mid
+        // End of user code
+
+        try {
+            // TODO Andrew@2018-11-12: consider using Java 8 Optional class for zero-or-one card.
+            if (resource.getDescription() == null) {
+                s = s + "<em>null</em>";
+            }
+            else {
+                s = s + resource.getDescription().toString();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        // Start of user code descriptiontoHtml_finalize
+        // End of user code
+
+        return s;
+    }
+
+
+    public String resourcePropertyToHtmlCreation(final String propertyName) {
+        throw new IllegalStateException("Not implemented, similar to toHtml methods");
+    }
+}

--- a/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirement.jsp
+++ b/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirement.jsp
@@ -37,6 +37,7 @@ To revert to the default generated content, delete all content in this file, and
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
 <%@page import="java.util.List" %>
 <%@page import="com.sample.rm.resources.Requirement"%>
+<%@ page import="com.sample.rm.resources.Oslc_rmHtmlHelper" %>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 
@@ -49,7 +50,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aRequirement.toString(true) %></title>
+  <title><%= Oslc_rmHtmlHelper.requirementToString(aRequirement, true) %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">

--- a/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementlargepreview.jsp
+++ b/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementlargepreview.jsp
@@ -36,11 +36,16 @@ To revert to the default generated content, delete all content in this file, and
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
 <%@page import="java.util.List" %>
 <%@page import="com.sample.rm.resources.Requirement"%>
+<%@ page import="com.sample.rm.resources.Oslc_rmHtmlHelper" %>
+<%@ page import="com.sample.rm.resources.Oslc_rmHtmlHelperOverload" %>
+<%@ page import="com.sample.rm.resources.Oslc_rmHelperFactory" %>
+<%@ page import="com.sample.rm.resources.Helper" %>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
 
 <%
   Requirement aRequirement = (Requirement) request.getAttribute("aRequirement");
+  final Helper<Requirement> helper = Oslc_rmHelperFactory.INSTANCE.getHelperFor(aRequirement);
 %>
 
 <html lang="en">
@@ -49,7 +54,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aRequirement.toString(false) %></title>
+  <title><%= helper.resourceToString(false) %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -66,11 +71,15 @@ To revert to the default generated content, delete all content in this file, and
         <div>
           <dl class="dl-horizontal">
             <dt>title</dt>
-            <dd><%= aRequirement.titleToHtml()%></dd>
+            <%--<dd><%= aRequirement.titleToHtml()%></dd>--%>
+            <dd><%= Oslc_rmHtmlHelper.requirementTitleToHtml(aRequirement) %></dd>
+            <dd><%= Oslc_rmHtmlHelperOverload.requirementTitleToHtml(aRequirement) %></dd>
+            <dd><%= helper.resourcePropertyToHtml("title") %></dd>
           </dl>
           <dl class="dl-horizontal">
             <dt>description</dt>
             <dd><%= aRequirement.descriptionToHtml()%></dd>
+            <dd><%= helper.resourcePropertyToHtml("title") %></dd>
           </dl>
         </div>
       </div>


### PR DESCRIPTION
This PR has a few examples how can we migrate HTML-related code away from resource classes.

**The direct way**

I have started by simply moving away the methods into the `Oslc_rmHtmlHelper` class, making them static and appending the resource class name where necessary

:white_check_mark: almost one-to-one transformation
:x: a lot of static boilerplate

**The "slightly generic" way**

In `Oslc_rmHtmlHelperOverload` I have renamed the resource-related methods from `%className%ToHtml()` to `resourceToHtml()`, relying on the compiler to pick the right overridden method. But this approach does not work for properties.

**The complicado way**

`Oslc_rmHelperFactory` implements `HelperFactory` and is a singleton (not sure about the singleton thing). For a `getHelperFor(aResource)` call, you get back a `Helper<T>` parametrised by the class of the `aResource`.

:x: losing compile-time checks on properties

***

An example how all of them can be used are in `requirementlargepreview.jsp`. I can expand the example into any direction based on your feedback.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oslc/lyo-adaptor-sample-modelling/19)
<!-- Reviewable:end -->
