### PR TITLE
update of the jsp pages to no longer rely on the removed toHtml() methods

### DIFF
--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/IRequirement.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/IRequirement.java
@@ -39,10 +39,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Requirement.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/resources/Requirement.java
@@ -41,10 +41,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
@@ -119,51 +115,6 @@ public class Requirement
         // End of user code
     }
     
-    /**
-    * @deprecated Use the methods in class {@link com.sample.rm.RMToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public Requirement(final String requirementId)
-           throws URISyntaxException
-    {
-        this (constructURI(requirementId));
-        // Start of user code constructor3
-        // End of user code
-    }
-    
-    /**
-    * @deprecated Use the methods in class {@link com.sample.rm.RMToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public static URI constructURI(final String requirementId)
-    {
-        String basePath = OSLC4JUtils.getServletURI();
-        Map<String, Object> pathParameters = new HashMap<String, Object>();
-        pathParameters.put("requirementId", requirementId);
-        String instanceURI = "requirements/{requirementId}";
-    
-        final UriBuilder builder = UriBuilder.fromUri(basePath);
-        return builder.path(instanceURI).buildFromMap(pathParameters);
-    }
-    
-    /**
-    * @deprecated Use the methods in class {@link com.sample.rm.RMToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public static Link constructLink(final String requirementId , final String label)
-    {
-        return new Link(constructURI(requirementId), label);
-    }
-    
-    /**
-    * @deprecated Use the methods in class {@link com.sample.rm.RMToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public static Link constructLink(final String requirementId)
-    {
-        return new Link(constructURI(requirementId));
-    }
-    
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
@@ -193,34 +144,6 @@ public class Requirement
         }
     
         // Start of user code toString_finalize
-        // End of user code
-    
-        return result;
-    }
-    
-    @Deprecated
-    public String toHtml()
-    {
-        return toHtml(false);
-    }
-    
-    @Deprecated
-    public String toHtml(boolean asLocalResource)
-    {
-        String result = "";
-        // Start of user code toHtml_init
-        // End of user code
-    
-        if (asLocalResource) {
-            result = toString(true);
-            // Start of user code toHtml_bodyForLocalResource
-            // End of user code
-        }
-        else {
-            result = "<a href=\"" + getAbout() + "\" class=\"oslc-resource-link\">" + toString() + "</a>";
-        }
-    
-        // Start of user code toHtml_finalize
         // End of user code
     
         return result;
@@ -278,98 +201,6 @@ public class Requirement
     
         // Start of user code setterFinalize:description
         // End of user code
-    }
-    
-    
-    @Deprecated
-    static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
-    {
-        String s = "";
-    
-        // Start of user code "Init:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        s = s + "<label for=\"title\">title: </LABEL>";
-    
-        // Start of user code "Mid:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        s= s + "<input name=\"title\" type=\"text\" style=\"width: 400px\" id=\"title\" >";
-        // Start of user code "Finalize:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
-    {
-        String s = "";
-    
-        // Start of user code "Init:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        s = s + "<label for=\"description\">description: </LABEL>";
-    
-        // Start of user code "Mid:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        s= s + "<input name=\"description\" type=\"text\" style=\"width: 400px\" id=\"description\" >";
-        // Start of user code "Finalize:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        return s;
-    }
-    
-    
-    @Deprecated
-    public String titleToHtml()
-    {
-        String s = "";
-    
-        // Start of user code titletoHtml_mid
-        // End of user code
-    
-        try {
-            if (title == null) {
-                s = s + "<em>null</em>";
-            }
-            else {
-                s = s + title.toString();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    
-        // Start of user code titletoHtml_finalize
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    public String descriptionToHtml()
-    {
-        String s = "";
-    
-        // Start of user code descriptiontoHtml_mid
-        // End of user code
-    
-        try {
-            if (description == null) {
-                s = s + "<em>null</em>";
-            }
-            else {
-                s = s + description.toString();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    
-        // Start of user code descriptiontoHtml_finalize
-        // End of user code
-    
-        return s;
     }
     
     

--- a/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirement.jsp
+++ b/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirement.jsp
@@ -34,8 +34,13 @@ To revert to the default generated content, delete all content in this file, and
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
+<%@page import="org.eclipse.lyo.oslc4j.core.model.Link" %>
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
-<%@page import="java.util.List" %>
+<%@page import="java.net.URI"%>
+<%@page import="java.util.Date"%>
+<%@page import="java.util.HashSet"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.Iterator"%>
 <%@page import="com.sample.rm.resources.Requirement"%>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
@@ -49,7 +54,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aRequirement.toString(true) %></title>
+  <title><%= aRequirement.toString() %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -75,7 +80,7 @@ To revert to the default generated content, delete all content in this file, and
     <div class="page-header">
         <h1>Requirement resource</h1>
         <p class="lead">URI:&nbsp;
-      <a href="<%= aRequirement.getAbout() %>"><%= aRequirement.getAbout() %></a>
+        <jsp:include page="/com/sample/rm/requirementtohtml.jsp"></jsp:include>
         </p>
     </div>
 		<div class="alert alert-primary" role="alert">
@@ -94,11 +99,31 @@ To revert to the default generated content, delete all content in this file, and
         <div>
           <dl class="row">
             <dt  class="col-sm-2 text-right">title</dt>
-            <dd class="col-sm-9"><%= aRequirement.titleToHtml()%></dd>
+            <dd class="col-sm-9">
+            <%
+            if (aRequirement.getTitle() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aRequirement.getTitle().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
           <dl class="row">
             <dt  class="col-sm-2 text-right">description</dt>
-            <dd class="col-sm-9"><%= aRequirement.descriptionToHtml()%></dd>
+            <dd class="col-sm-9">
+            <%
+            if (aRequirement.getDescription() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aRequirement.getDescription().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
         </div>
       </div>

--- a/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementlargepreview.jsp
+++ b/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementlargepreview.jsp
@@ -33,8 +33,13 @@ To revert to the default generated content, delete all content in this file, and
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
+<%@page import="org.eclipse.lyo.oslc4j.core.model.Link" %>
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
-<%@page import="java.util.List" %>
+<%@page import="java.net.URI"%>
+<%@page import="java.util.Date"%>
+<%@page import="java.util.HashSet"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.Iterator"%>
 <%@page import="com.sample.rm.resources.Requirement"%>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
@@ -49,7 +54,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aRequirement.toString(false) %></title>
+  <title><%= aRequirement.toString() %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -66,11 +71,31 @@ To revert to the default generated content, delete all content in this file, and
         <div>
           <dl class="dl-horizontal">
             <dt>title</dt>
-            <dd><%= aRequirement.titleToHtml()%></dd>
+            <dd>
+            <%
+            if (aRequirement.getTitle() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aRequirement.getTitle().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
           <dl class="dl-horizontal">
             <dt>description</dt>
-            <dd><%= aRequirement.descriptionToHtml()%></dd>
+            <dd>
+            <%
+            if (aRequirement.getDescription() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aRequirement.getDescription().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
         </div>
       </div>

--- a/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementscollection.jsp
+++ b/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementscollection.jsp
@@ -90,7 +90,7 @@ To revert to the default generated content, delete all content in this file, and
 			</p>
 		</div>
         <% for (Requirement aResource : resources) { %>
-        <p><%= aResource.toHtml() %><br /></p>
+        <p><a href="<%= aResource.getAbout() %>" class="oslc-resource-link"><%=aResource.getAbout().toString()%></a><br /></p>
         <% } %>
         <% if (nextPageUri != null) { %><a href="<%= nextPageUri %>">Next Page</a><% } %>
       </div>

--- a/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementsmallpreview.jsp
+++ b/adaptor-rm-webapp/src/main/webapp/com/sample/rm/requirementsmallpreview.jsp
@@ -33,8 +33,13 @@ To revert to the default generated content, delete all content in this file, and
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
+<%@page import="org.eclipse.lyo.oslc4j.core.model.Link" %>
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
-<%@page import="java.util.List" %>
+<%@page import="java.net.URI"%>
+<%@page import="java.util.Date"%>
+<%@page import="java.util.HashSet"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.Iterator"%>
 <%@page import="com.sample.rm.resources.Requirement"%>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
@@ -49,7 +54,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aRequirement.toString(false) %></title>
+  <title><%= aRequirement.toString() %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -66,11 +71,31 @@ To revert to the default generated content, delete all content in this file, and
         <div>
           <dl class="dl-horizontal">
             <dt>title</dt>
-            <dd><%= aRequirement.titleToHtml()%></dd>
+            <dd>
+            <%
+            if (aRequirement.getTitle() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aRequirement.getTitle().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
           <dl class="dl-horizontal">
             <dt>description</dt>
-            <dd><%= aRequirement.descriptionToHtml()%></dd>
+            <dd>
+            <%
+            if (aRequirement.getDescription() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aRequirement.getDescription().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
         </div>
       </div>

--- a/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/IRequirement.java
+++ b/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/IRequirement.java
@@ -39,10 +39,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;

--- a/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/ITestScript.java
+++ b/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/ITestScript.java
@@ -39,10 +39,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.annotation.OslcAllowedValue;
 import org.eclipse.lyo.oslc4j.core.annotation.OslcDescription;

--- a/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/Requirement.java
+++ b/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/Requirement.java
@@ -41,10 +41,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
@@ -119,7 +115,6 @@ public class Requirement
         // End of user code
     }
     
-    
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
@@ -149,34 +144,6 @@ public class Requirement
         }
     
         // Start of user code toString_finalize
-        // End of user code
-    
-        return result;
-    }
-    
-    @Deprecated
-    public String toHtml()
-    {
-        return toHtml(false);
-    }
-    
-    @Deprecated
-    public String toHtml(boolean asLocalResource)
-    {
-        String result = "";
-        // Start of user code toHtml_init
-        // End of user code
-    
-        if (asLocalResource) {
-            result = toString(true);
-            // Start of user code toHtml_bodyForLocalResource
-            // End of user code
-        }
-        else {
-            result = "<a href=\"" + getAbout() + "\" class=\"oslc-resource-link\">" + toString() + "</a>";
-        }
-    
-        // Start of user code toHtml_finalize
         // End of user code
     
         return result;
@@ -234,98 +201,6 @@ public class Requirement
     
         // Start of user code setterFinalize:description
         // End of user code
-    }
-    
-    
-    @Deprecated
-    static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
-    {
-        String s = "";
-    
-        // Start of user code "Init:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        s = s + "<label for=\"title\">title: </LABEL>";
-    
-        // Start of user code "Mid:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        s= s + "<input name=\"title\" type=\"text\" style=\"width: 400px\" id=\"title\" >";
-        // Start of user code "Finalize:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
-    {
-        String s = "";
-    
-        // Start of user code "Init:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        s = s + "<label for=\"description\">description: </LABEL>";
-    
-        // Start of user code "Mid:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        s= s + "<input name=\"description\" type=\"text\" style=\"width: 400px\" id=\"description\" >";
-        // Start of user code "Finalize:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        return s;
-    }
-    
-    
-    @Deprecated
-    public String titleToHtml()
-    {
-        String s = "";
-    
-        // Start of user code titletoHtml_mid
-        // End of user code
-    
-        try {
-            if (title == null) {
-                s = s + "<em>null</em>";
-            }
-            else {
-                s = s + title.toString();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    
-        // Start of user code titletoHtml_finalize
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    public String descriptionToHtml()
-    {
-        String s = "";
-    
-        // Start of user code descriptiontoHtml_mid
-        // End of user code
-    
-        try {
-            if (description == null) {
-                s = s + "<em>null</em>";
-            }
-            else {
-                s = s + description.toString();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    
-        // Start of user code descriptiontoHtml_finalize
-        // End of user code
-    
-        return s;
     }
     
     

--- a/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/TestScript.java
+++ b/adaptor-testing-webapp/src/main/java/com/sample/testing/resources/TestScript.java
@@ -41,10 +41,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.Iterator;
-import javax.servlet.http.HttpServletRequest;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import javax.ws.rs.core.UriBuilder;
 
 import org.eclipse.lyo.oslc4j.core.OSLC4JUtils;
 import org.eclipse.lyo.oslc4j.core.exception.OslcCoreApplicationException;
@@ -125,52 +121,6 @@ public class TestScript
         // End of user code
     }
     
-    /**
-    * @deprecated Use the methods in class {@link com.sample.testing.TestingToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public TestScript(final String serviceProviderId, final String testScriptId)
-           throws URISyntaxException
-    {
-        this (constructURI(serviceProviderId, testScriptId));
-        // Start of user code constructor3
-        // End of user code
-    }
-    
-    /**
-    * @deprecated Use the methods in class {@link com.sample.testing.TestingToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public static URI constructURI(final String serviceProviderId, final String testScriptId)
-    {
-        String basePath = OSLC4JUtils.getServletURI();
-        Map<String, Object> pathParameters = new HashMap<String, Object>();
-        pathParameters.put("serviceProviderId", serviceProviderId);
-        pathParameters.put("testScriptId", testScriptId);
-        String instanceURI = "serviceProviders/{serviceProviderId}/testScripts/{testScriptId}";
-    
-        final UriBuilder builder = UriBuilder.fromUri(basePath);
-        return builder.path(instanceURI).buildFromMap(pathParameters);
-    }
-    
-    /**
-    * @deprecated Use the methods in class {@link com.sample.testing.TestingToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public static Link constructLink(final String serviceProviderId, final String testScriptId , final String label)
-    {
-        return new Link(constructURI(serviceProviderId, testScriptId), label);
-    }
-    
-    /**
-    * @deprecated Use the methods in class {@link com.sample.testing.TestingToolResourcesFactory} instead.
-    */
-    @Deprecated
-    public static Link constructLink(final String serviceProviderId, final String testScriptId)
-    {
-        return new Link(constructURI(serviceProviderId, testScriptId));
-    }
-    
     public static ResourceShape createResourceShape() throws OslcCoreApplicationException, URISyntaxException {
         return ResourceShapeFactory.createResourceShape(OSLC4JUtils.getServletURI(),
         OslcConstants.PATH_RESOURCE_SHAPES,
@@ -200,34 +150,6 @@ public class TestScript
         }
     
         // Start of user code toString_finalize
-        // End of user code
-    
-        return result;
-    }
-    
-    @Deprecated
-    public String toHtml()
-    {
-        return toHtml(false);
-    }
-    
-    @Deprecated
-    public String toHtml(boolean asLocalResource)
-    {
-        String result = "";
-        // Start of user code toHtml_init
-        // End of user code
-    
-        if (asLocalResource) {
-            result = toString(true);
-            // Start of user code toHtml_bodyForLocalResource
-            // End of user code
-        }
-        else {
-            result = "<a href=\"" + getAbout() + "\" class=\"oslc-resource-link\">" + toString() + "</a>";
-        }
-    
-        // Start of user code toHtml_finalize
         // End of user code
     
         return result;
@@ -321,143 +243,6 @@ public class TestScript
     
         // Start of user code setterFinalize:description
         // End of user code
-    }
-    
-    
-    @Deprecated
-    static public String titleToHtmlForCreation (final HttpServletRequest httpServletRequest)
-    {
-        String s = "";
-    
-        // Start of user code "Init:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        s = s + "<label for=\"title\">title: </LABEL>";
-    
-        // Start of user code "Mid:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        s= s + "<input name=\"title\" type=\"text\" style=\"width: 400px\" id=\"title\" >";
-        // Start of user code "Finalize:titleToHtmlForCreation(...)"
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    static public String validatesRequirementToHtmlForCreation (final HttpServletRequest httpServletRequest)
-    {
-        String s = "";
-    
-        // Start of user code "Init:validatesRequirementToHtmlForCreation(...)"
-        // End of user code
-    
-        s = s + "<label for=\"validatesRequirement\">validatesRequirement: </LABEL>";
-    
-        // Start of user code "Mid:validatesRequirementToHtmlForCreation(...)"
-        // End of user code
-    
-        // Start of user code "Finalize:validatesRequirementToHtmlForCreation(...)"
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    static public String descriptionToHtmlForCreation (final HttpServletRequest httpServletRequest)
-    {
-        String s = "";
-    
-        // Start of user code "Init:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        s = s + "<label for=\"description\">description: </LABEL>";
-    
-        // Start of user code "Mid:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        s= s + "<input name=\"description\" type=\"text\" style=\"width: 400px\" id=\"description\" >";
-        // Start of user code "Finalize:descriptionToHtmlForCreation(...)"
-        // End of user code
-    
-        return s;
-    }
-    
-    
-    @Deprecated
-    public String titleToHtml()
-    {
-        String s = "";
-    
-        // Start of user code titletoHtml_mid
-        // End of user code
-    
-        try {
-            if (title == null) {
-                s = s + "<em>null</em>";
-            }
-            else {
-                s = s + title.toString();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    
-        // Start of user code titletoHtml_finalize
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    public String validatesRequirementToHtml()
-    {
-        String s = "";
-    
-        // Start of user code validatesRequirementtoHtml_mid
-        // End of user code
-    
-        try {
-            s = s + "<ul>";
-            for(Link next : validatesRequirement) {
-                s = s + "<li>";
-                s = s + (new Requirement (next.getValue())).toHtml(false);
-                s = s + "</li>";
-            }
-            s = s + "</ul>";
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    
-        // Start of user code validatesRequirementtoHtml_finalize
-        // End of user code
-    
-        return s;
-    }
-    
-    @Deprecated
-    public String descriptionToHtml()
-    {
-        String s = "";
-    
-        // Start of user code descriptiontoHtml_mid
-        // End of user code
-    
-        try {
-            if (description == null) {
-                s = s + "<em>null</em>";
-            }
-            else {
-                s = s + description.toString();
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    
-        // Start of user code descriptiontoHtml_finalize
-        // End of user code
-    
-        return s;
     }
     
     

--- a/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscript.jsp
+++ b/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscript.jsp
@@ -34,8 +34,13 @@ To revert to the default generated content, delete all content in this file, and
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
+<%@page import="org.eclipse.lyo.oslc4j.core.model.Link" %>
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
-<%@page import="java.util.List" %>
+<%@page import="java.net.URI"%>
+<%@page import="java.util.Date"%>
+<%@page import="java.util.HashSet"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.Iterator"%>
 <%@page import="com.sample.testing.resources.TestScript"%>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
@@ -49,7 +54,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aTestScript.toString(true) %></title>
+  <title><%= aTestScript.toString() %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -75,7 +80,7 @@ To revert to the default generated content, delete all content in this file, and
     <div class="page-header">
         <h1>TestScript resource</h1>
         <p class="lead">URI:&nbsp;
-      <a href="<%= aTestScript.getAbout() %>"><%= aTestScript.getAbout() %></a>
+        <jsp:include page="/com/sample/testing/testscripttohtml.jsp"></jsp:include>
         </p>
     </div>
 		<div class="alert alert-primary" role="alert">
@@ -94,15 +99,55 @@ To revert to the default generated content, delete all content in this file, and
         <div>
           <dl class="row">
             <dt  class="col-sm-2 text-right">title</dt>
-            <dd class="col-sm-9"><%= aTestScript.titleToHtml()%></dd>
+            <dd class="col-sm-9">
+            <%
+            if (aTestScript.getTitle() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aTestScript.getTitle().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
           <dl class="row">
             <dt  class="col-sm-2 text-right">validatesRequirement</dt>
-            <dd class="col-sm-9"><%= aTestScript.validatesRequirementToHtml()%></dd>
+            <dd class="col-sm-9">
+            <ul>
+            <%
+            for(Link next : aTestScript.getValidatesRequirement()) {
+                if (next.getValue() == null) {
+                    out.write("<li>" + "<em>null</em>" + "</li>");
+                }
+                else {
+                    %>
+                    <li>
+                    <jsp:include page="/com/sample/testing/requirementtohtml.jsp">
+                        <jsp:param name="resourceUri" value="<%=next.getValue()%>"/> 
+                        </jsp:include>
+                    </li>
+                    <%
+                }
+            }
+            %>
+            </ul>
+            
+            </dd>
           </dl>
           <dl class="row">
             <dt  class="col-sm-2 text-right">description</dt>
-            <dd class="col-sm-9"><%= aTestScript.descriptionToHtml()%></dd>
+            <dd class="col-sm-9">
+            <%
+            if (aTestScript.getDescription() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aTestScript.getDescription().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
         </div>
       </div>

--- a/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscriptlargepreview.jsp
+++ b/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscriptlargepreview.jsp
@@ -33,8 +33,13 @@ To revert to the default generated content, delete all content in this file, and
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
+<%@page import="org.eclipse.lyo.oslc4j.core.model.Link" %>
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
-<%@page import="java.util.List" %>
+<%@page import="java.net.URI"%>
+<%@page import="java.util.Date"%>
+<%@page import="java.util.HashSet"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.Iterator"%>
 <%@page import="com.sample.testing.resources.TestScript"%>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
@@ -49,7 +54,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aTestScript.toString(false) %></title>
+  <title><%= aTestScript.toString() %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -66,15 +71,55 @@ To revert to the default generated content, delete all content in this file, and
         <div>
           <dl class="dl-horizontal">
             <dt>title</dt>
-            <dd><%= aTestScript.titleToHtml()%></dd>
+            <dd>
+            <%
+            if (aTestScript.getTitle() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aTestScript.getTitle().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
           <dl class="dl-horizontal">
             <dt>validatesRequirement</dt>
-            <dd><%= aTestScript.validatesRequirementToHtml()%></dd>
+            <dd>
+            <ul>
+            <%
+            for(Link next : aTestScript.getValidatesRequirement()) {
+                if (next.getValue() == null) {
+                    out.write("<li>" + "<em>null</em>" + "</li>");
+                }
+                else {
+                    %>
+                    <li>
+                    <jsp:include page="/com/sample/testing/requirementtohtml.jsp">
+                        <jsp:param name="resourceUri" value="<%=next.getValue()%>"/> 
+                        </jsp:include>
+                    </li>
+                    <%
+                }
+            }
+            %>
+            </ul>
+            
+            </dd>
           </dl>
           <dl class="dl-horizontal">
             <dt>description</dt>
-            <dd><%= aTestScript.descriptionToHtml()%></dd>
+            <dd>
+            <%
+            if (aTestScript.getDescription() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aTestScript.getDescription().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
         </div>
       </div>

--- a/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscriptscollection.jsp
+++ b/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscriptscollection.jsp
@@ -90,7 +90,7 @@ To revert to the default generated content, delete all content in this file, and
 			</p>
 		</div>
         <% for (TestScript aResource : resources) { %>
-        <p><%= aResource.toHtml() %><br /></p>
+        <p><a href="<%= aResource.getAbout() %>" class="oslc-resource-link"><%=aResource.getAbout().toString()%></a><br /></p>
         <% } %>
         <% if (nextPageUri != null) { %><a href="<%= nextPageUri %>">Next Page</a><% } %>
       </div>

--- a/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscriptsmallpreview.jsp
+++ b/adaptor-testing-webapp/src/main/webapp/com/sample/testing/testscriptsmallpreview.jsp
@@ -33,8 +33,13 @@ To revert to the default generated content, delete all content in this file, and
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 <%@ taglib uri="http://java.sun.com/jsp/jstl/functions" prefix="fn" %>
 
+<%@page import="org.eclipse.lyo.oslc4j.core.model.Link" %>
 <%@page import="org.eclipse.lyo.oslc4j.core.model.ServiceProvider"%>
-<%@page import="java.util.List" %>
+<%@page import="java.net.URI"%>
+<%@page import="java.util.Date"%>
+<%@page import="java.util.HashSet"%>
+<%@page import="java.util.List"%>
+<%@page import="java.util.Iterator"%>
 <%@page import="com.sample.testing.resources.TestScript"%>
 
 <%@ page contentType="text/html" language="java" pageEncoding="UTF-8" %>
@@ -49,7 +54,7 @@ To revert to the default generated content, delete all content in this file, and
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title><%= aTestScript.toString(false) %></title>
+  <title><%= aTestScript.toString() %></title>
 
   <link href="<c:url value="/static/css/bootstrap-4.0.0-beta.min.css"/>" rel="stylesheet">
   <link href="<c:url value="/static/css/adaptor.css"/>" rel="stylesheet">
@@ -66,15 +71,55 @@ To revert to the default generated content, delete all content in this file, and
         <div>
           <dl class="dl-horizontal">
             <dt>title</dt>
-            <dd><%= aTestScript.titleToHtml()%></dd>
+            <dd>
+            <%
+            if (aTestScript.getTitle() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aTestScript.getTitle().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
           <dl class="dl-horizontal">
             <dt>validatesRequirement</dt>
-            <dd><%= aTestScript.validatesRequirementToHtml()%></dd>
+            <dd>
+            <ul>
+            <%
+            for(Link next : aTestScript.getValidatesRequirement()) {
+                if (next.getValue() == null) {
+                    out.write("<li>" + "<em>null</em>" + "</li>");
+                }
+                else {
+                    %>
+                    <li>
+                    <jsp:include page="/com/sample/testing/requirementtohtml.jsp">
+                        <jsp:param name="resourceUri" value="<%=next.getValue()%>"/> 
+                        </jsp:include>
+                    </li>
+                    <%
+                }
+            }
+            %>
+            </ul>
+            
+            </dd>
           </dl>
           <dl class="dl-horizontal">
             <dt>description</dt>
-            <dd><%= aTestScript.descriptionToHtml()%></dd>
+            <dd>
+            <%
+            if (aTestScript.getDescription() == null) {
+                out.write("<em>null</em>");
+            }
+            else {
+                out.write(aTestScript.getDescription().toString());
+            }
+            %>
+            
+            </dd>
           </dl>
         </div>
       </div>


### PR DESCRIPTION
update of the jsp pages to no longer rely on the removed toHtml() methods

This is based on the latest changes to LyoDesigner, that remove these methods. See the pull-request
https://github.com/eclipse/lyo.designer/pull/73

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/oslc/lyo-adaptor-sample-modelling/29)
<!-- Reviewable:end -->
