### PR TITLE
HK2 DI example for LyoD

### DIFF
--- a/adaptor-rm-webapp/pom.xml
+++ b/adaptor-rm-webapp/pom.xml
@@ -86,6 +86,11 @@
 			<version>${version.jersey}</version>
 		</dependency>
 		<dependency>
+			<groupId>org.glassfish.jersey.core</groupId>
+			<artifactId>jersey-common</artifactId>
+			<version>${version.jersey}</version>
+		</dependency>
+		<dependency>
 			<groupId>org.glassfish.jersey.containers</groupId>
 			<artifactId>jersey-container-servlet</artifactId>
 			<version>${version.jersey}</version>
@@ -103,21 +108,21 @@
 			<plugin>
 				<groupId>org.eclipse.jetty</groupId>
 				<artifactId>jetty-maven-plugin</artifactId>
-				<version>9.3.9.v20160517</version>
+				<version>9.4.17.v20190418</version>
 				<configuration>
-					<webAppConfig>
+					<stopKey>alpha</stopKey>
+					<stopPort>9099</stopPort>
+					<useTestClasspath>true</useTestClasspath>
+					<httpConnector>
+						<port>8081</port>
+					</httpConnector>
+					<jettyProperties>
+						<jettyProperty>jetty.server.dumpAfterStart=false</jettyProperty>
+					</jettyProperties>
+					<jvmArgs>-Dorg.eclipse.jetty.webapp.LEVEL=INFO</jvmArgs>
+					<webApp>
 						<contextPath>/adaptor-rm</contextPath>
-					</webAppConfig>
-					<reload>automatic</reload>
-					<scanIntervalSeconds>5</scanIntervalSeconds>
-					<systemProperties>
-						<systemProperty>
-							<name>jetty.port</name>
-							<value>8081</value>
-						</systemProperty>
-					</systemProperties>
-					<stopKey />
-					<stopPort />
+					</webApp>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/RMToolManagerBean.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/RMToolManagerBean.java
@@ -3,10 +3,18 @@ package com.sample.rm;
 import com.sample.rm.resources.Requirement;
 import javax.servlet.http.HttpServletRequest;
 
-public class RMToolManagerBean {
+public class RMToolManagerBean implements RequirementsManager, ServiceProviderManager {
 
-    public static Requirement getRequirement(HttpServletRequest httpServletRequest, final String requirementId) {
+    @Override
+    public Requirement getRequirement(HttpServletRequest httpServletRequest,
+            final String requirementId) {
         return RMToolManager.getRequirement(httpServletRequest, requirementId);
     }
+
+    @Override
+    public ServiceProviderInfo[] getServiceProviderInfos(HttpServletRequest httpServletRequest) {
+        return RMToolManager.getServiceProviderInfos(httpServletRequest);
+    }
+
 
 }

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/RMToolManagerBean.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/RMToolManagerBean.java
@@ -1,0 +1,12 @@
+package com.sample.rm;
+
+import com.sample.rm.resources.Requirement;
+import javax.servlet.http.HttpServletRequest;
+
+public class RMToolManagerBean {
+
+    public static Requirement getRequirement(HttpServletRequest httpServletRequest, final String requirementId) {
+        return RMToolManager.getRequirement(httpServletRequest, requirementId);
+    }
+
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/RequirementsManager.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/RequirementsManager.java
@@ -1,0 +1,8 @@
+package com.sample.rm;
+
+import com.sample.rm.resources.Requirement;
+import javax.servlet.http.HttpServletRequest;
+
+public interface RequirementsManager {
+    Requirement getRequirement(HttpServletRequest httpServletRequest, String requirementId);
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/ServiceProviderManager.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/ServiceProviderManager.java
@@ -1,0 +1,7 @@
+package com.sample.rm;
+
+import javax.servlet.http.HttpServletRequest;
+
+public interface ServiceProviderManager {
+    ServiceProviderInfo[] getServiceProviderInfos(HttpServletRequest httpServletRequest);
+}

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/services/ServiceProviderCatalogService.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/services/ServiceProviderCatalogService.java
@@ -26,10 +26,12 @@
 package com.sample.rm.services;
 
 
+import com.sample.rm.ServiceProviderManager;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import javax.inject.Inject;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletRequest;
@@ -66,6 +68,7 @@ public class ServiceProviderCatalogService
     @Context private HttpServletRequest httpServletRequest;
     @Context private HttpServletResponse httpServletResponse;
     @Context private UriInfo uriInfo;
+    @Inject private ServiceProviderManager providerManager;
 
     /**
      * Redirect requests to /catalog to /catalog/singleton

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/services/ServiceProviderService1.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/services/ServiceProviderService1.java
@@ -22,6 +22,7 @@
 
 package com.sample.rm.services;
 
+import com.sample.rm.RequirementsManager;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.URI;
@@ -85,7 +86,6 @@ import io.swagger.annotations.ApiOperation;
 
 // Start of user code imports
 import javax.inject.Inject;
-import com.sample.rm.RMToolManagerBean;
 // End of user code
 
 // Start of user code pre_class_code
@@ -100,7 +100,7 @@ public class ServiceProviderService1
     @Context private UriInfo uriInfo;
 
     // Start of user code class_attributes
-    @Inject private RMToolManagerBean toolManager;
+    @Inject private RequirementsManager toolManager;
     // End of user code
 
     // Start of user code class_methods

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/services/ServiceProviderService1.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/services/ServiceProviderService1.java
@@ -84,6 +84,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 
 // Start of user code imports
+import javax.inject.Inject;
+import com.sample.rm.RMToolManagerBean;
 // End of user code
 
 // Start of user code pre_class_code
@@ -98,6 +100,7 @@ public class ServiceProviderService1
     @Context private UriInfo uriInfo;
 
     // Start of user code class_attributes
+    @Inject private RMToolManagerBean toolManager;
     // End of user code
 
     // Start of user code class_methods
@@ -271,7 +274,7 @@ public class ServiceProviderService1
         // Start of user code getResource_init
         // End of user code
 
-        final Requirement aRequirement = RMToolManager.getRequirement(httpServletRequest, requirementId);
+        final Requirement aRequirement = toolManager.getRequirement(httpServletRequest, requirementId);
 
         if (aRequirement != null) {
             // Start of user code getRequirement
@@ -299,7 +302,7 @@ public class ServiceProviderService1
         // Start of user code getRequirementAsHtml_init
         // End of user code
 
-        final Requirement aRequirement = RMToolManager.getRequirement(httpServletRequest, requirementId);
+        final Requirement aRequirement = toolManager.getRequirement(httpServletRequest, requirementId);
 
         if (aRequirement != null) {
             httpServletRequest.setAttribute("aRequirement", aRequirement);
@@ -336,7 +339,7 @@ public class ServiceProviderService1
         //TODO: adjust the preview height & width values from the default values provided above.
         // End of user code
 
-        final Requirement aRequirement = RMToolManager.getRequirement(httpServletRequest, requirementId);
+        final Requirement aRequirement = toolManager.getRequirement(httpServletRequest, requirementId);
 
         if (aRequirement != null) {
             final Compact compact = new Compact();
@@ -376,7 +379,7 @@ public class ServiceProviderService1
         // Start of user code getRequirementAsHtmlSmallPreview_init
         // End of user code
 
-        final Requirement aRequirement = RMToolManager.getRequirement(httpServletRequest, requirementId);
+        final Requirement aRequirement = toolManager.getRequirement(httpServletRequest, requirementId);
 
         if (aRequirement != null) {
             httpServletRequest.setAttribute("aRequirement", aRequirement);
@@ -402,7 +405,7 @@ public class ServiceProviderService1
         // Start of user code getRequirementAsHtmlLargePreview_init
         // End of user code
 
-        final Requirement aRequirement = RMToolManager.getRequirement(httpServletRequest, requirementId);
+        final Requirement aRequirement = toolManager.getRequirement(httpServletRequest, requirementId);
 
         if (aRequirement != null) {
             httpServletRequest.setAttribute("aRequirement", aRequirement);

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/servlet/Application.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/servlet/Application.java
@@ -23,6 +23,8 @@
 
 package com.sample.rm.servlet;
 
+import com.sample.rm.RequirementsManager;
+import com.sample.rm.ServiceProviderManager;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -64,8 +66,6 @@ import com.sample.rm.services.ServiceProviderService1;
 import javax.inject.Singleton;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import com.sample.rm.RMToolManagerBean;
-import com.sample.rm.StoreBean;
-import com.sample.rm.StoredBeanImpl;
 // End of user code
 
 // Start of user code pre_class_code
@@ -136,8 +136,9 @@ public class Application extends javax.ws.rs.core.Application {
         singletons.add((new AbstractBinder() {
             @Override
             protected void configure() {
-                bind(RmAdaptorFactoryImpl.class).to(AdaptorFactory.class).in(Singleton.class);
-                bind(RMToolManagerBean.class).to(RMToolManagerBean.class).in(Singleton.class);
+                bind(RMToolManagerBean.class).to(RequirementsManager.class)
+                        .to(ServiceProviderManager.class)
+                        .in(Singleton.class);
             }
         }));
         return singletons;

--- a/adaptor-rm-webapp/src/main/java/com/sample/rm/servlet/Application.java
+++ b/adaptor-rm-webapp/src/main/java/com/sample/rm/servlet/Application.java
@@ -61,6 +61,11 @@ import com.sample.rm.resources.Oslc_rmDomainConstants;
 import com.sample.rm.services.ServiceProviderService1;
 
 // Start of user code imports
+import javax.inject.Singleton;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+import com.sample.rm.RMToolManagerBean;
+import com.sample.rm.StoreBean;
+import com.sample.rm.StoredBeanImpl;
 // End of user code
 
 // Start of user code pre_class_code
@@ -125,7 +130,20 @@ public class Application extends javax.ws.rs.core.Application {
         }
     }
 
-    @Override 
+    @Override
+    public Set<Object> getSingletons() {
+        final Set<Object> singletons = new HashSet<>();
+        singletons.add((new AbstractBinder() {
+            @Override
+            protected void configure() {
+                bind(RmAdaptorFactoryImpl.class).to(AdaptorFactory.class).in(Singleton.class);
+                bind(RMToolManagerBean.class).to(RMToolManagerBean.class).in(Singleton.class);
+            }
+        }));
+        return singletons;
+    }
+
+    @Override
     public Set<Class<?>> getClasses() { 
         return RESOURCE_CLASSES; 
     }

--- a/adaptor-rm-webapp/src/main/resources/META-INF/beans.xml
+++ b/adaptor-rm-webapp/src/main/resources/META-INF/beans.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans/>


### PR DESCRIPTION
This is the DI example for inclusion in LyoD.

The JAX-RS service side is framework-independent and relies on [JSR-330 annotations](https://github.com/javax-inject/javax-inject/tree/master/src/javax/inject).

Unfortunately, the injection framework configuration was really tricky:

- The community is moving towards CDI (see [Microprofile](https://microprofile.io/2019/02/12/eclipse-microprofile-2-2-is-now-available/))
- Jersey has long used HK2, Sun's DI used for Glassfish and other things.
- Jersey has added support for CDI 1 some time ago.
- CDI 2 is the latest release, but support for it in Jersey is experimental. 
- Weld is the reference implementation of both CDI 1.2 and CDI 2.0.
- Weld is supported in Jetty 9.4 "out of the box" but only the Weld 3, which is the implementation of CDI 2.0
- Jetty support out of the box only works for standalone servers not the ones we start from maven via `jetty:run` (I did not want to use hacks with forked Jetty instances).
- Experimental Jersey support for CDI 2 is only shown (explained with examples) for Java SE where you run Jetty in an embedded mode (ie. have a `main()` method and start Jetty programmatically). I did not want to do this because it would tie us to Jetty.
- Wildfly should have support for CDI out of the box but that would require giving up on lightweight Jetty and I did not manage to set it up from the first try.

I am pretty sure there is a flaw in my thinking at some step above. If you can help me get CDI 1.2 (or  better yet, CDI 2.0) working, it would be fantastic!

Still, if you wish to use something else that Jersey and HK2 injector, you only need to change the binding config code in the `Application` class.

